### PR TITLE
Fixed Bug - app crashed when timezone used in search

### DIFF
--- a/database_persistence.rb
+++ b/database_persistence.rb
@@ -122,7 +122,7 @@ class DatabasePersistence
       sql += stmt
     end if courses
     timezones.each do |timezone|
-      stmt = ' AND tz.id = #{timezone}'
+      stmt = " AND tz.id = #{timezone}"
       sql += stmt
     end if timezones
 


### PR DESCRIPTION
Change from single to double quotes to enable string interpolation and the bug is fixed!