### PR TITLE
Bug multi option get users & add all timezones

### DIFF
--- a/database_persistence.rb
+++ b/database_persistence.rb
@@ -112,22 +112,16 @@ class DatabasePersistence
         LEFT JOIN preferences p ON up.preference_id = p.id
     SQL
 
-    # Fix multi course/track/timezone select:
-    # Every field should be joined with AND and within the field the options joined by OR
-    # WHERE true (1 = 1)
-    # AND (track = ‘RB’ OR track = ‘JS’)
-    # AND (course= ‘JS101’ OR course = ‘RB101’ OR course = ‘RB120’....) 
-
     sql += ' WHERE 1 = 1'
 
     first = true
-    tracks.each do |track|                       # tracks array contains track_ids or track_names?
+    tracks.each do |track|
       stmt = ' AND t.id = ' + track if first
       stmt = ' OR t.id = ' + track if !first
       sql += stmt
       first = false
     end if tracks
-    
+
     first = true
     courses.each do |course|
       stmt = ' AND c.id = ' + course if first
@@ -135,7 +129,7 @@ class DatabasePersistence
       sql += stmt
       first = false
     end if courses
-    
+
     first = true
     timezones.each do |timezone|
       stmt = " AND tz.id = #{timezone}" if first

--- a/database_persistence.rb
+++ b/database_persistence.rb
@@ -112,24 +112,42 @@ class DatabasePersistence
         LEFT JOIN preferences p ON up.preference_id = p.id
     SQL
 
+    # Fix multi course/track/timezone select:
+    # Every field should be joined with AND and within the field the options joined by OR
+    # WHERE true (1 = 1)
+    # AND (track = ‘RB’ OR track = ‘JS’)
+    # AND (course= ‘JS101’ OR course = ‘RB101’ OR course = ‘RB120’....) 
+
     sql += ' WHERE 1 = 1'
-    tracks.each do |track|
-      stmt = ' AND t.id = ' + track
+
+    first = true
+    tracks.each do |track|                       # tracks array contains track_ids or track_names?
+      stmt = ' AND t.id = ' + track if first
+      stmt = ' OR t.id = ' + track if !first
       sql += stmt
+      first = false
     end if tracks
+    
+    first = true
     courses.each do |course|
-      stmt = ' AND c.id = ' + course
+      stmt = ' AND c.id = ' + course if first
+      stmt = ' OR c.id = ' + course if !first
       sql += stmt
+      first = false
     end if courses
+    
+    first = true
     timezones.each do |timezone|
-      stmt = " AND tz.id = #{timezone}"
+      stmt = " AND tz.id = #{timezone}" if first
+      stmt = " OR tz.id = #{timezone}" if !first
       sql += stmt
+      first = false
     end if timezones
 
     first = true
     preferences.each do |preference|
-      stmt = ' AND t.id = ' + preference if first
-      stmt = ' OR t.id = ' + preference if !first
+      stmt = ' AND p.id = ' + preference if first
+      stmt = ' OR p.id = ' + preference if !first
       sql += stmt
       first = false
     end if preferences

--- a/load_join_tables.sql
+++ b/load_join_tables.sql
@@ -19,9 +19,38 @@ INSERT INTO tracks (code, name)
          ('JS', 'Javascript');
 
 INSERT INTO timezones (code, name)
-  VALUES ('EST', 'Eastern Standard Time'),
-         ('CET', 'Central European Time'),
-         ('PST', 'Pacific Standard Time');
+  VALUES ('GMT', 'Greenwich Mean Time'),
+         ('UTC', 'Universal Coordinated Time'),
+         ('ECT', 'European Central Time'),
+         ('EET', 'Eastern European Time'),
+         ('ART', '(Arabic) Egypt Standard Time'),
+         ('EAT', 'Eastern African Time'),
+         ('MET', 'Middle East Time'),
+         ('NET', 'Near East Time'),
+         ('PLT', 'Pakistan Lahore Time'),
+         ('IST', 'India Standard Time'),
+         ('BST', 'Bangladesh Standard Time'),
+         ('VST', 'Vietnam Standard Time'),
+         ('CTT', 'China Taiwan Time'),
+         ('JST', 'Japan Standard Time'),
+         ('ACT', 'Australia Central Time'),
+         ('AET', 'Australia Eastern Time'),
+         ('SST', 'Solomon Standard Time'),
+         ('NST', 'New Zealand Standard Time'),
+         ('MIT', 'Midway Islands Time'),
+         ('HST', 'Hawaii Standard Time'),
+         ('AST', 'Alaska Standard Time'),
+         ('PST', 'Pacific Standard Time'),
+         ('PNT', 'Phoenix Standard Time'),
+         ('MST', 'Mountain Standard Time'),
+         ('CST', 'Central Standard Time'),
+         ('EST', 'Eastern Standard Time'),
+         ('IET', 'Indiana Eastern Standard Time'),
+         ('PRT', 'Puerto Rico and US Virgin Islands Time'),
+         ('CNT', 'Canada Newfoundland Time'),
+         ('AGT', 'Argentina Standard Time'),
+         ('BET', 'Brazil Eastern Time'),
+         ('CAT', 'Central African Time');
 
 INSERT INTO preferences (preference, category)
   VALUES ('Preparing for a written assessment', 'Assessment preparation'),


### PR DESCRIPTION
I think the bug we had in the multi selection when search is fixed. There was a minor typo in the iteration of `preferences` (the iteration with `each` to complete the `sql` sent to the `query` method), that I fixed.

Also added AND and OR when required, so the second choices in multiple choice selection works good.

Finally I added all timezones to the `load_join_table.sql` file. 